### PR TITLE
'readme' is required by galaxy

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -28,4 +28,3 @@ documentation:
 homepage:
 # issue tracker url
 issues:
-

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,8 @@ name:
 version:
 # a list of the collection's content authors: 'Full Name <email> (http://site) @nicks:irc/im/site#channel'
 authors:
-
+# 'readme' is required by galaxy
+readme: README.md
 ### optional but strongly advised
 # short summary of the collection
 description:
@@ -27,3 +28,4 @@ documentation:
 homepage:
 # issue tracker url
 issues:
+


### PR DESCRIPTION
If readme parameter is not given in galaxy.yml, the below error will occur while uploading the collection into galaxy.ansible.com:

```Import Task "44" failed: Invalid collection metadata. 'readme' is required by galaxy```